### PR TITLE
Add ClassPath.add(File... files)

### DIFF
--- a/container-se-server/src/main/java/org/jboss/arquillian/container/se/server/Main.java
+++ b/container-se-server/src/main/java/org/jboss/arquillian/container/se/server/Main.java
@@ -51,7 +51,7 @@ public class Main {
             }
             JMXTestRunner testRunner = new JMXTestRunner(new TestClassLoader(classLoader));
             testRunner.registerMBean(mbs);
-            LOGGER.info("JMXTestRunner initialized");
+            LOGGER.info("JMXTestRunner initialized using [" + classLoader + "]");
         } catch (JMException e) {
             throw new RuntimeException("Unable to register JMXTestRunner", e);
         }

--- a/container-se-server/src/main/java/org/jboss/arquillian/container/se/server/TestClassLoader.java
+++ b/container-se-server/src/main/java/org/jboss/arquillian/container/se/server/TestClassLoader.java
@@ -35,7 +35,7 @@ public class TestClassLoader implements JMXTestRunner.TestClassLoader {
 
     @Override
     public Class<?> loadTestClass(String className) throws ClassNotFoundException {
-        LOGGER.info("Loading test class [" + className + "] using [" + testClassLoader + "]");
+        LOGGER.fine("Loading test class [" + className + "] using [" + testClassLoader + "]");
         return testClassLoader.loadClass(className);
     }
 }

--- a/container-se-tests/pom.xml
+++ b/container-se-tests/pom.xml
@@ -1,34 +1,85 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
-    <modelVersion>4.0.0</modelVersion>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+   xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+   <modelVersion>4.0.0</modelVersion>
 
-    <parent>
-        <groupId>org.jboss.arquillian.container</groupId>
-        <artifactId>arquillian-container-se</artifactId>
-        <version>1.0.1-SNAPSHOT</version>
-        <relativePath>../</relativePath>
-    </parent>
+   <parent>
+      <groupId>org.jboss.arquillian.container</groupId>
+      <artifactId>arquillian-container-se</artifactId>
+      <version>1.0.1-SNAPSHOT</version>
+      <relativePath>../</relativePath>
+   </parent>
 
-    <artifactId>container-se-tests</artifactId>
+   <artifactId>container-se-tests</artifactId>
 
-    <dependencies>
-        <dependency>
-            <groupId>junit</groupId>
-            <artifactId>junit</artifactId>
-            <version>4.8.1</version>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.junit</groupId>
-            <artifactId>arquillian-junit-container</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
-            <groupId>org.jboss.arquillian.container</groupId>
-            <artifactId>container-se-managed</artifactId>
-            <version>${project.version}</version>
-            <scope>test</scope>
-        </dependency>
-    </dependencies>
+   <dependencies>
+
+      <dependency>
+         <groupId>junit</groupId>
+         <artifactId>junit</artifactId>
+         <version>${junit.version}</version>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.jboss.arquillian.junit</groupId>
+         <artifactId>arquillian-junit-container</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>org.jboss.arquillian.container</groupId>
+         <artifactId>container-se-managed</artifactId>
+         <version>${project.version}</version>
+         <scope>test</scope>
+      </dependency>
+
+      <!-- Just to test maven resolver and ClassPath.Builder.add(File...) -->
+      <dependency>
+         <groupId>org.jboss.shrinkwrap.resolver</groupId>
+         <artifactId>shrinkwrap-resolver-impl-maven</artifactId>
+         <scope>test</scope>
+      </dependency>
+
+      <dependency>
+         <groupId>javax.enterprise</groupId>
+         <artifactId>cdi-api</artifactId>
+         <version>1.2</version>
+         <scope>test</scope>
+      </dependency>
+
+      <!-- Test libraries path -->
+      <dependency>
+         <groupId>org.glassfish</groupId>
+         <artifactId>javax.json</artifactId>
+         <version>1.0.4</version>
+         <scope>test</scope>
+      </dependency>
+
+   </dependencies>
+
+   <build>
+      <plugins>
+         <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-dependency-plugin</artifactId>
+            <executions>
+               <execution>
+                  <id>copy-libraries</id>
+                  <phase>test-compile</phase>
+                  <goals>
+                     <goal>copy-dependencies</goal>
+                  </goals>
+                  <configuration>
+                     <stripVersion>true</stripVersion>
+                     <overWriteReleases>true</overWriteReleases>
+                     <outputDirectory>${project.build.directory}/libraries</outputDirectory>
+                     <includeGroupIds>org.glassfish</includeGroupIds>
+                  </configuration>
+               </execution>
+            </executions>
+         </plugin>
+      </plugins>
+   </build>
 
 </project>

--- a/container-se-tests/src/test/java/org/jboss/arquillian/container/se/test/simple/CompositeClassPathTest.java
+++ b/container-se-tests/src/test/java/org/jboss/arquillian/container/se/test/simple/CompositeClassPathTest.java
@@ -16,13 +16,17 @@
  */
 package org.jboss.arquillian.container.se.test.simple;
 
-import junit.framework.Assert;
+import static org.junit.Assert.assertEquals;
+
+import javax.enterprise.inject.IllegalProductException;
+
 import org.jboss.arquillian.container.se.api.ClassPath;
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
 import org.jboss.shrinkwrap.api.Archive;
 import org.jboss.shrinkwrap.api.ShrinkWrap;
 import org.jboss.shrinkwrap.api.spec.JavaArchive;
+import org.jboss.shrinkwrap.resolver.api.maven.Maven;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 
@@ -34,11 +38,13 @@ public class CompositeClassPathTest {
         final JavaArchive test = ShrinkWrap.create(JavaArchive.class, "test.jar").addClass(CompositeClassPathTest.class);
         final JavaArchive foo = ShrinkWrap.create(JavaArchive.class, "foo.jar").addClass(Foo.class);
         final JavaArchive bar = ShrinkWrap.create(JavaArchive.class, "bar.jar").addClass(Bar.class);
-        return ClassPath.builder().add(foo, bar, test).build();
+        return ClassPath.builder().add(foo, bar, test)
+                .add(Maven.resolver().loadPomFromFile("pom.xml").resolve("javax.enterprise:cdi-api").withTransitivity().asFile()).build();
     }
 
     @Test
     public void test() {
-        Assert.assertEquals(2, new Foo().ping() + new Bar().ping());
+        assertEquals(2, new Foo().ping() + new Bar().ping());
+        new IllegalProductException("foo");
     }
 }

--- a/container-se-tests/src/test/java/org/jboss/arquillian/container/se/test/simple/JavaArchiveSmokeTest.java
+++ b/container-se-tests/src/test/java/org/jboss/arquillian/container/se/test/simple/JavaArchiveSmokeTest.java
@@ -16,7 +16,9 @@
  */
 package org.jboss.arquillian.container.se.test.simple;
 
-import junit.framework.Assert;
+import static org.junit.Assert.assertEquals;
+
+import javax.json.Json;
 
 import org.jboss.arquillian.container.test.api.Deployment;
 import org.jboss.arquillian.junit.Arquillian;
@@ -36,6 +38,12 @@ public class JavaArchiveSmokeTest {
 
     @Test
     public void test() {
-        Assert.assertEquals(2, 1 + 1);
+        assertEquals(2, 1 + 1);
+    }
+
+    @Test
+    public void testLibrariesPath() {
+        // Test that jsonp is on the class path
+        Json.createArrayBuilder().build();
     }
 }

--- a/container-se-tests/src/test/resources/arquillian.xml
+++ b/container-se-tests/src/test/resources/arquillian.xml
@@ -11,6 +11,7 @@
          <property name="debug">false</property>
          <property name="keepDeploymentArchives">false</property>
          <property name="waitTime">5</property>
+         <property name="librariesPath">target/libraries</property>
       </configuration>
    </container>
 

--- a/pom.xml
+++ b/pom.xml
@@ -21,6 +21,7 @@
     <properties>
         <!-- Versioning -->
         <arquillian.version>1.1.7.Final</arquillian.version>
+        <junit.version>4.12</junit.version>
         <maven.compiler.plugin.version>3.3</maven.compiler.plugin.version>
         <maven.surefire.plugin.version>2.18</maven.surefire.plugin.version>
         <maven.nexus.plugin.version>2.1</maven.nexus.plugin.version>


### PR DESCRIPTION
- so that it is possible to use Shrinkwrap Maven resolver easily
- right now the only way is to import/export artifacts
- e.g. add `org.jboss.shrinkwrap.resolver:shrinkwrap-resolver-impl-maven-archive` dependency and use something like `Maven.resolver().resolve("com.foo:bar").as(JavaArchive.class)`
- also fix reading of dependencies from libraries path (should only be read once)
- also decrease logging level in several places